### PR TITLE
Enhance diagram node styling and components

### DIFF
--- a/AiWorkflowEditor.csproj
+++ b/AiWorkflowEditor.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Blazor.Diagrams" Version="3.0.2" />
+    <PackageReference Include="Z.Blazor.Diagrams" Version="3.0.3" />
   </ItemGroup>
 
 </Project>

--- a/Components/AiDialogNodeComponent.razor
+++ b/Components/AiDialogNodeComponent.razor
@@ -1,5 +1,5 @@
-@using Blazor.Diagrams.Core.Models
-@inherits Blazor.Diagrams.Components.NodeWidget
+@using Z.Blazor.Diagrams.Core.Models
+@inherits Z.Blazor.Diagrams.Components.NodeWidget
 
 <div class="@CssClass">
     <div class="ai-dialog-node">

--- a/Components/StartEndNodeComponent.razor
+++ b/Components/StartEndNodeComponent.razor
@@ -1,5 +1,5 @@
-@using Blazor.Diagrams.Core.Models
-@inherits Blazor.Diagrams.Components.NodeWidget
+@using Z.Blazor.Diagrams.Core.Models
+@inherits Z.Blazor.Diagrams.Components.NodeWidget
 
 <div class="@CssClass">
     @if (Node.Title == "开始节点")

--- a/Models/CustomNodeModel.cs
+++ b/Models/CustomNodeModel.cs
@@ -1,5 +1,5 @@
-using Blazor.Diagrams.Core.Models;
-using Blazor.Diagrams.Core.Geometry;
+using Z.Blazor.Diagrams.Core.Models;
+using Z.Blazor.Diagrams.Core.Geometry;
 
 namespace Models
 {

--- a/Pages/FlowDiagram.razor
+++ b/Pages/FlowDiagram.razor
@@ -74,10 +74,10 @@
         Diagram.PointerDoubleClick += OnNodeDoubleClick;
 
         // 注册自定义节点组件
-        Diagram.RegisterComponent<StartEndNodeComponent>(node => 
-            (node as CustomNodeModel)?.NodeType is "start" or "end");
-        Diagram.RegisterComponent<AiDialogNodeComponent>(node => 
-            (node as CustomNodeModel)?.NodeType == "ai-dialog");
+        Diagram.RegisterComponent<CustomNodeModel, StartEndNodeComponent>(node => 
+            node.NodeType is "start" or "end");
+        Diagram.RegisterComponent<CustomNodeModel, AiDialogNodeComponent>(node => 
+            node.NodeType == "ai-dialog");
 
         CreateStartAndEndNodes();
     }

--- a/Pages/FlowDiagram.razor
+++ b/Pages/FlowDiagram.razor
@@ -1,11 +1,13 @@
 @page "/flow"
-@using Blazor.Diagrams.Components
-@using Blazor.Diagrams.Components.Widgets
-@using Blazor.Diagrams.Core.Models
-@using Blazor.Diagrams.Core.Geometry
-@using Blazor.Diagrams.Core.Anchors
-@using Blazor.Diagrams.Core.PathGenerators
-@using Blazor.Diagrams.Core.Routers
+@using Z.Blazor.Diagrams
+@using Z.Blazor.Diagrams.Components
+@using Z.Blazor.Diagrams.Core.Models
+@using Z.Blazor.Diagrams.Core.Geometry
+@using Z.Blazor.Diagrams.Core.Anchors
+@using Z.Blazor.Diagrams.Core.PathGenerators
+@using Z.Blazor.Diagrams.Core.Routers
+@using Z.Blazor.Diagrams.Components.Widgets
+@using Z.Blazor.Diagrams.Core.Events
 @using Components
 @using Models
 
@@ -36,6 +38,19 @@
     <div class="diagram-container">
         <CascadingValue Value="Diagram" IsFixed="true">
             <DiagramCanvas @ondblclick="OnCanvasDoubleClick">
+                <NodeWidget>
+                    @if (context is CustomNodeModel customNode)
+                    {
+                        @if (customNode.NodeType is "start" or "end")
+                        {
+                            <StartEndNodeComponent />
+                        }
+                        else if (customNode.NodeType == "ai-dialog")
+                        {
+                            <AiDialogNodeComponent />
+                        }
+                    }
+                </NodeWidget>
                 <Widgets>
                     <NavigatorWidget Width="200" Height="120"
                                     Class="border border-black bg-white absolute"
@@ -72,12 +87,6 @@
 
         // 订阅节点双击事件
         Diagram.PointerDoubleClick += OnNodeDoubleClick;
-
-        // 注册自定义节点组件
-        Diagram.RegisterComponent<CustomNodeModel, StartEndNodeComponent>(node => 
-            node.NodeType is "start" or "end");
-        Diagram.RegisterComponent<CustomNodeModel, AiDialogNodeComponent>(node => 
-            node.NodeType == "ai-dialog");
 
         CreateStartAndEndNodes();
     }
@@ -248,7 +257,7 @@
         StateHasChanged();
     }
 
-    private void OnNodeDoubleClick(Blazor.Diagrams.Core.Models.Base.Model? model, Blazor.Diagrams.Core.Events.PointerEventArgs args)
+    private void OnNodeDoubleClick(Z.Blazor.Diagrams.Core.Models.Base.Model? model, Z.Blazor.Diagrams.Core.Events.PointerEventArgs args)
     {
         if (model is CustomNodeModel node && node.NodeType == "ai-dialog")
         {

--- a/Pages/_Layout.cshtml
+++ b/Pages/_Layout.cshtml
@@ -7,7 +7,7 @@
     <base href="~/" />
     <link href="css/bootstrap/bootstrap.min.css" rel="stylesheet" />
     <link href="css/app.css" rel="stylesheet" />
-    <link href="css/blazor-diagrams.min.css" rel="stylesheet" />
+    <link href="_content/Z.Blazor.Diagrams/style.css" rel="stylesheet" />
     <component type="typeof(HeadOutlet)" render-mode="ServerPrerendered" />
 </head>
 <body>
@@ -25,6 +25,6 @@
     </div>
 
     <script src="_framework/blazor.server.js"></script>
-    <script src="js/blazor-diagrams.min.js"></script>
+    <script src="_content/Z.Blazor.Diagrams/script.js"></script>
 </body>
 </html>


### PR DESCRIPTION
Migrates Blazor Diagrams library to `Z.Blazor.Diagrams` and updates node component rendering.

This PR resolves compilation errors caused by API differences between `Blazor.Diagrams` and `Z.Blazor.Diagrams`, specifically by switching from `RegisterComponent` to dynamic component rendering within `NodeWidget` for custom node types.

---

**Open Background Agent:** 

[Web](https://www.cursor.com/agents?id=bc-99ef7292-4b63-4d8b-9ec4-0ec5f3f1b396) · [Cursor](https://cursor.com/background-agent?bcId=bc-99ef7292-4b63-4d8b-9ec4-0ec5f3f1b396)

Refer to [Background Agent docs](https://docs.cursor.com/background-agents)